### PR TITLE
fix: Add Fatalf method to BugFixes struct

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/go-logfmt/logfmt v0.6.0 h1:wGYYu3uicYdqXVgoYbvnkrPVXkuLM1p1ifugDMEdRi
 github.com/go-logfmt/logfmt v0.6.0/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/logs/logs.go
+++ b/logs/logs.go
@@ -156,3 +156,19 @@ func (b BugFixes) Fatal(inputs ...interface{}) {
 	b.DoReporting()
 	panic(b)
 }
+func (b BugFixes) Fatalf(format string, inputs ...interface{}) {
+	b.Level = "fatal"
+	b.FormattedLog = fmt.Sprintf(format, inputs...)
+	b.DoReporting()
+	panic(b)
+}
+func Fatal(inputs ...interface{}) {
+	format := strings.Repeat("%v, ", len(inputs))
+	format = strings.TrimRight(format, ", ")
+	Fatalf(format, inputs...)
+}
+func Fatalf(format string, inputs ...interface{}) {
+	BugFixes{
+		LocalOnly: false,
+	}.Fatalf(format, inputs...)
+}


### PR DESCRIPTION
Added the Fatalf method to the BugFixes struct to allow for formatted logging with panic. This method formats the log message and then calls DoReporting before panicking with the BugFixes struct.