### PR TITLE
feat: Add condition to only log errors or successful requests

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -187,7 +187,11 @@ func (l *defaultLogEntry) Write(status, bytes int, elapsed time.Duration) {
 		cW(l.buf, l.useColor, nRed, "%s", elapsed)
 	}
 
-  if l.LogLevel >= Info {
+  if status == 200 {
+    if l.LogLevel <= Error {
+      l.Logger.Print(l.buf.String())
+    }
+  } else {
     l.Logger.Print(l.buf.String())
   }
 }


### PR DESCRIPTION
Added a condition to only log errors or successful requests with a status of 200. This helps to filter out unnecessary log entries and focus on the most important information.