### PR TITLE
fix: update recoverer middleware to properly handle panics

### DIFF
--- a/middleware/recoverer.go
+++ b/middleware/recoverer.go
@@ -19,7 +19,8 @@ import (
 func Recoverer(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
-			if rvr := recover(); rvr != nil && rvr != http.ErrAbortHandler {
+      rvr := recover()
+			if rvr != nil && rvr != http.ErrAbortHandler {
 
 				logEntry := GetLogEntry(r)
 				if logEntry != nil {


### PR DESCRIPTION
Refactor the recoverer middleware to correctly handle panics and prevent
unnecessary error messages from being logged. Update the condition to check
for the presence of a panic before processing it.