### PR TITLE
bugfix: Corrected logging format in sendLog function

### DIFF
--- a/logs/logging.go
+++ b/logs/logging.go
@@ -227,7 +227,7 @@ func (b *BugFixes) sendLog() {
 		fmt.Printf("bugfixes sendLog marshal: %+v\n", err)
 		return
 	}
-  a := fmt.Sprintf("%+v", body) // debugging purposes
+  a := fmt.Sprintf("%s", body) // debugging purposes
   _ = fmt.Sprint(a)
 
 	request, err := http.NewRequest("POST", bugServer, bytes.NewBuffer(body))


### PR DESCRIPTION
Changed fmt.Sprintf from %+v to %s for better logging clarity in sendLog
function of logging.go.