### PR TITLE
refactor(logs): Remove debug.Stack in Logf and Infof functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,12 @@ go 1.21
 
 require (
 	github.com/go-logfmt/logfmt v0.6.0
+	github.com/jarcoal/httpmock v1.3.1
 	github.com/stretchr/testify v1.9.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/jarcoal/httpmock v1.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/go-logfmt/logfmt v0.6.0 h1:wGYYu3uicYdqXVgoYbvnkrPVXkuLM1p1ifugDMEdRi
 github.com/go-logfmt/logfmt v0.6.0/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInww=
 github.com/jarcoal/httpmock v1.3.1/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
+github.com/maxatome/go-testdeep v1.12.0 h1:Ql7Go8Tg0C1D/uMMX59LAoYK7LffeJQ6X2T04nTH68g=
 github.com/maxatome/go-testdeep v1.12.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/logs/logs.go
+++ b/logs/logs.go
@@ -72,7 +72,6 @@ func (b *BugFixes) Infof(format string, inputs ...interface{}) string {
 	b.FormattedLog = fmt.Sprintf(format, inputs...)
 
 	if !b.LocalOnly {
-		b.Stack = debug.Stack()
 		b.DoReporting()
 	}
 
@@ -135,7 +134,6 @@ func (b *BugFixes) Logf(format string, inputs ...interface{}) string {
 	b.FormattedLog = fmt.Sprintf(format, inputs...)
 
 	if !b.LocalOnly {
-		b.Stack = debug.Stack()
 		b.DoReporting()
 	}
 


### PR DESCRIPTION
Removed the call to debug.Stack in the Logf and Infof functions in the
logs package as it was not necessary and improved performance.