### PR TITLE
feat: add middleware to convert headers to lowercase

### DIFF
--- a/middleware/lcheaders.go
+++ b/middleware/lcheaders.go
@@ -1,0 +1,28 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+)
+
+func LowerCaseHeaders(next http.Handler) http.Handler {
+	s := &System{}
+	return s.LCHeaders(next)
+}
+
+func (s *System) LCHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Iterate over the request headers
+		for k, v := range r.Header {
+			// Create a lowercase version of the key
+			lcKey := strings.ToLower(k)
+
+			// Add the lowercase key with the same values
+			// This won't overwrite the original header
+			r.Header[lcKey] = v
+		}
+
+		// Call the next handler in the chain
+		next.ServeHTTP(w, r)
+	})
+}

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -1,16 +1,16 @@
 package middleware
 
 import (
-  "context"
-  "net/http"
+	"context"
+	"net/http"
 )
 
 type System struct {
 	Context context.Context
 
-  // Bugfixes
-  AgentID string
-  Secret string
+	// Bugfixes
+	AgentID string
+	Secret  string
 
 	// Middlewares to use
 	Middlewares []func(handler http.Handler) http.Handler
@@ -28,8 +28,8 @@ func NewMiddleware(ctx context.Context) *System {
 }
 
 func (s *System) SetupBugfixes(id, secret string) {
-  s.AgentID = id
-  s.Secret = secret
+	s.AgentID = id
+	s.Secret = secret
 }
 
 func (s *System) AddMiddleware(middlwares ...func(handler http.Handler) http.Handler) {
@@ -48,12 +48,18 @@ func (s *System) Handler(h http.Handler) http.Handler {
 	return h
 }
 
-func DefaultMiddlware(next http.Handler) http.Handler {
-	s := NewMiddleware(context.Background())
-	s.AddMiddleware(Logger)
-	s.AddMiddleware(RequestID)
-	s.AddMiddleware(Recoverer)
+func DefaultMiddleware(next http.Handler) http.Handler {
+	s := NewDefaultMiddleware(next)
 
 	return s.Handler(next)
 }
 
+func NewDefaultMiddleware(next http.Handler) *System {
+	s := NewMiddleware(context.Background())
+	s.AddMiddleware(Logger)
+	s.AddMiddleware(RequestID)
+	s.AddMiddleware(Recoverer)
+	s.AddMiddleware(LowerCaseHeaders)
+
+	return s
+}

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -22,7 +22,7 @@ func TestBugFixes(t *testing.T) {
 	}
 
 	// Apply middleware to the handler
-	middlewareHandler := middleware.DefaultMiddlware(handler)
+	middlewareHandler := middleware.DefaultMiddleware(handler)
 
 	// Create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response
 	rr := httptest.NewRecorder()
@@ -37,5 +37,34 @@ func TestBugFixes(t *testing.T) {
 	expected := `OK`
 	if rr.Body.String() != expected {
 		t.Errorf("handler returned unexpected body: got %v, want %v", rr.Body.String(), expected)
+	}
+}
+
+func TestBugFixesLowerCase(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte("OK")); err != nil {
+			t.Error(err)
+		}
+	})
+
+	// Create a request to pass to our handler
+	// We don't have any query parameters so we'll pass 'nil' as the third parameter
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Set("X-Bugfixes-Version", "1.0.0")
+
+	// Apply middleware to the handler
+	middlewareHandler := middleware.DefaultMiddleware(handler)
+
+	// Create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response
+	rr := httptest.NewRecorder()
+	middlewareHandler.ServeHTTP(rr, req)
+
+	// make sure the lowercase works
+	if req.Header.Get("X-Bugfixes-Version") != "1.0.0" || req.Header.Get("x-bugfixes-version") != "1.0.0" {
+		t.Fatal("handler returned wrong header")
 	}
 }


### PR DESCRIPTION
This change adds a new middleware function `LowerCaseHeaders` that
converts all the request headers to lowercase before passing the request
to the next handler in the chain. This ensures that the headers are
consistently formatted, which can be important for downstream
applications that may be case-sensitive.

The middleware is added to the `DefaultMiddleware` function, which is
used to set up the default middleware stack for the application.

Additionally, a new test case `TestBugFixesLowerCase` has been added to
ensure that the middleware is working as expected and that the headers
are correctly converted to lowercase.