### PR TITLE
feat(ci): update release draft workflow

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -25,8 +25,6 @@ jobs:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
   update_release_draft:
     runs-on: ubuntu-latest
-    needs:
-      - qodana
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Removes the `qodana` job as a dependency for the `update_release_draft`
job. This change simplifies the workflow and ensures the release draft
is updated regardless of the outcome of the `qodana` job.