### PR TITLE
Fix stderr routing and bug line parsing

### DIFF
--- a/logs/logging.go
+++ b/logs/logging.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -171,7 +172,7 @@ func (b *BugFixes) DoReporting() {
 
 	body, err := json.Marshal(b)
 	if err != nil {
-		fmt.Printf("bugfixes sendLog marshal: %+v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "bugfixes sendLog marshal: %+v\n", err)
 		return
 	}
 	go b.sendLogBody(cfg, body)
@@ -182,23 +183,23 @@ func (b *BugFixes) logFormat() {
 	lf := logfmt.NewEncoder(&out)
 
 	if err := lf.EncodeKeyval("path", b.File); err != nil {
-		fmt.Printf("logfmt path: %v", err)
+		_, _ = fmt.Fprintf(os.Stderr, "logfmt path: %v", err)
 	}
 	if err := lf.EncodeKeyval("level", b.Level); err != nil {
-		fmt.Printf("logfmt level: %v", err)
+		_, _ = fmt.Fprintf(os.Stderr, "logfmt level: %v", err)
 	}
 	if err := lf.EncodeKeyval("msg", b.FormattedLog); err != nil {
-		fmt.Printf("logfmt msg: %v", err)
+		_, _ = fmt.Fprintf(os.Stderr, "logfmt msg: %v", err)
 	}
 	if err := lf.EncodeKeyval("time", time.Now()); err != nil {
-		fmt.Printf("logfmt time: %v", err)
+		_, _ = fmt.Fprintf(os.Stderr, "logfmt time: %v", err)
 	}
 	if err := lf.EncodeKeyval("line", b.Line); err != nil {
-		fmt.Printf("logfmt line: %v", err)
+		_, _ = fmt.Fprintf(os.Stderr, "logfmt line: %v", err)
 	}
 
 	if err := lf.EndRecord(); err != nil {
-		fmt.Printf("logfmt endrecord: %v", err)
+		_, _ = fmt.Fprintf(os.Stderr, "logfmt endrecord: %v", err)
 	}
 
 	b.LogFmt = out.String()
@@ -206,12 +207,12 @@ func (b *BugFixes) logFormat() {
 
 func (b *BugFixes) sendLogBody(cfg bugfixes.Config, body []byte) {
 	if cfg.AgentKey == "" || cfg.AgentSecret == "" {
-		fmt.Printf("cant send to server till you have created an agent and set the keys\n")
+		_, _ = fmt.Fprint(os.Stderr, "cant send to server till you have created an agent and set the keys\n")
 		if cfg.AgentKey == "" {
-			fmt.Printf("env: BUGFIXES_AGENT_KEY missing\n")
+			_, _ = fmt.Fprint(os.Stderr, "env: BUGFIXES_AGENT_KEY missing\n")
 		}
 		if cfg.AgentSecret == "" {
-			fmt.Printf("env: BUGFIXES_AGENT_SECRET missing\n")
+			_, _ = fmt.Fprint(os.Stderr, "env: BUGFIXES_AGENT_SECRET missing\n")
 		}
 		return
 	}
@@ -221,7 +222,7 @@ func (b *BugFixes) sendLogBody(cfg bugfixes.Config, body []byte) {
 
 	request, err := http.NewRequestWithContext(ctx, "POST", cfg.LogEndpoint(), bytes.NewBuffer(body))
 	if err != nil {
-		fmt.Printf("bugfixes sendLog newRequest: %+v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "bugfixes sendLog newRequest: %+v\n", err)
 		return
 	}
 	request.Header.Set("Content-Type", "application/json")
@@ -231,12 +232,12 @@ func (b *BugFixes) sendLogBody(cfg bugfixes.Config, body []byte) {
 	client := cfg.GetHTTPClient()
 	resp, err := client.Do(request)
 	if err != nil {
-		fmt.Printf("bugfixes sendLog do: %+v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "bugfixes sendLog do: %+v\n", err)
 		return
 	}
 	if resp != nil && resp.Body != nil {
 		if err := resp.Body.Close(); err != nil {
-			fmt.Printf("bugfixes sendLog close: %+v\n", err)
+			_, _ = fmt.Fprintf(os.Stderr, "bugfixes sendLog close: %+v\n", err)
 			return
 		}
 	}
@@ -271,16 +272,26 @@ func (b *BugFixes) makePretty() {
 	// print to stdout if the level is high enough
 	reportLogLevel := ConvertLevelFromString(cfg.LogLevel)
 	logLevel := ConvertLevelFromString(b.Level)
+	writer := localLogWriter(b.Level)
 	if logLevel >= reportLogLevel || reportLogLevel == LevelUnknown || cfg.LocalOnly {
-		fmt.Printf("%s %s >> %s:%d >> %s\n", out, time.Now().Format("2006-01-02 15:04:05"), b.File, b.LineNumber, log)
+		_, _ = fmt.Fprintf(writer, "%s %s >> %s:%d >> %s\n", out, time.Now().Format("2006-01-02 15:04:05"), b.File, b.LineNumber, log)
 	}
 
 	if b.Stack != nil {
 		extra := &bytes.Buffer{}
 		cW(extra, true, bMagenta, "Stack:")
-		fmt.Printf("%s", extra)
+		_, _ = fmt.Fprintf(writer, "%s", extra)
 		PrintPrettyStack(b.Stack)
 		return
+	}
+}
+
+func localLogWriter(level string) io.Writer {
+	switch level {
+	case WARN, ERROR, CRASH, PANIC, FATAL:
+		return os.Stderr
+	default:
+		return os.Stdout
 	}
 }
 

--- a/logs/logging_stream_test.go
+++ b/logs/logging_stream_test.go
@@ -1,0 +1,91 @@
+package logs
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	bugfixes "github.com/bugfixes/go-bugfixes"
+)
+
+func captureStandardStreams(t *testing.T, fn func()) (string, string) {
+	t.Helper()
+
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+	stderrReader, stderrWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stderr pipe: %v", err)
+	}
+
+	os.Stdout = stdoutWriter
+	os.Stderr = stderrWriter
+
+	defer func() {
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	}()
+
+	fn()
+
+	_ = stdoutWriter.Close()
+	_ = stderrWriter.Close()
+
+	stdout, err := io.ReadAll(stdoutReader)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	stderr, err := io.ReadAll(stderrReader)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+
+	return string(stdout), string(stderr)
+}
+
+func TestDoReportingLocalStreamsByLevel(t *testing.T) {
+	tests := []struct {
+		name         string
+		level        string
+		expectStdout bool
+		expectStderr bool
+	}{
+		{name: "info uses stdout", level: INFO, expectStdout: true},
+		{name: "warn uses stderr", level: WARN, expectStderr: true},
+		{name: "error uses stderr", level: ERROR, expectStderr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logLine := "stream routing test"
+			entry := &BugFixes{
+				FormattedLog: logLine,
+				Level:        test.level,
+				Config: &bugfixes.Config{
+					LocalOnly: true,
+				},
+			}
+
+			stdout, stderr := captureStandardStreams(t, entry.DoReporting)
+
+			if test.expectStdout && !strings.Contains(stdout, logLine) {
+				t.Fatalf("expected stdout to contain %q, got %q", logLine, stdout)
+			}
+			if !test.expectStdout && stdout != "" {
+				t.Fatalf("expected stdout to be empty, got %q", stdout)
+			}
+			if test.expectStderr && !strings.Contains(stderr, logLine) {
+				t.Fatalf("expected stderr to contain %q, got %q", logLine, stderr)
+			}
+			if !test.expectStderr && stderr != "" {
+				t.Fatalf("expected stderr to be empty, got %q", stderr)
+			}
+		})
+	}
+}

--- a/middleware/bugfixes.go
+++ b/middleware/bugfixes.go
@@ -117,16 +117,17 @@ func (s *System) config() bugfixes.Config {
 }
 
 func ParseBugLine(bugLine string) (string, string, int, error) {
-	i := strings.Index(bugLine, ":")
+	i := strings.LastIndex(bugLine, ":")
 	if i < 0 {
 		return "", "", 0, fmt.Errorf("failed to find ':' in bug line: %s", bugLine)
 	}
-	j := strings.Index(bugLine, " ")
+	rest := bugLine[i+1:]
+	j := strings.Index(rest, " ")
 	if j < 0 {
 		return "", "", 0, fmt.Errorf("failed to find ' ' in bug line: %s", bugLine)
 	}
 	file := bugLine[:i]
-	lne := bugLine[i+1 : j]
+	lne := rest[:j]
 	line, err := strconv.Atoi(lne)
 	if err != nil {
 		return file, lne, 0, fmt.Errorf("failed to convert line number: %w", err)

--- a/middleware/parsebugline_test.go
+++ b/middleware/parsebugline_test.go
@@ -26,6 +26,15 @@ func TestParseBugLine_DeepPath(t *testing.T) {
 	assert.Equal(t, 100, line)
 }
 
+func TestParseBugLine_PathWithSpaces(t *testing.T) {
+	file, lne, line, err := middleware.ParseBugLine("/Volumes/Dockcase/AI Stuffs/project/main.go:42 +0x1a")
+
+	require.NoError(t, err)
+	assert.Equal(t, "/Volumes/Dockcase/AI Stuffs/project/main.go", file)
+	assert.Equal(t, "42", lne)
+	assert.Equal(t, 42, line)
+}
+
 func TestParseBugLine_MissingColon_ReturnsError(t *testing.T) {
 	_, _, _, err := middleware.ParseBugLine("main.go 42")
 


### PR DESCRIPTION
Routes local warn and error logs to stderr, and moves internal log-reporting failures there as well. Adds regression coverage for stdout versus stderr behavior in the logs package. Fixes middleware bug-line parsing by using the last colon so stack paths containing spaces still parse correctly. Adds a regression test for spaced file paths and keeps the full test suite green.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bugfixes/go-bugfixes/pull/75" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
