### PR TITLE
Hide raw panic byte slices in stack output

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -6,7 +6,6 @@ tools_bin := root / "bin"
 golangci_lint := tools_bin / "golangci-lint"
 goimports := tools_bin / "goimports"
 go_packages := "./..."
-go_files := `find . -type f -name '*.go' -not -path './.cache/*'`
 go_cache := root / ".cache/go-build"
 go_mod_cache := root / ".cache/go-mod"
 go_tmp := root / ".cache/tmp"
@@ -28,8 +27,8 @@ tidy: _prepare
     {{ go }} mod tidy
 
 fmt: tools
-    gofmt -w -s {{ go_files }}
-    "{{ goimports }}" -w {{ go_files }}
+    find . -type f -name '*.go' -not -path './.cache/*' -print0 | xargs -0 gofmt -w -s
+    find . -type f -name '*.go' -not -path './.cache/*' -print0 | xargs -0 "{{ goimports }}" -w
 
 lint: tools
     "{{ golangci_lint }}" run --config configs/golangci.yml

--- a/logs/pretty.go
+++ b/logs/pretty.go
@@ -7,15 +7,16 @@ import (
 	"os"
 	"runtime/debug"
 	"strings"
+	"unicode/utf8"
 )
 
 type prettyStack struct {
 }
 
 func PrintPrettyStack(rvr interface{}) {
-	debugStack := debug.Stack()
+	debugStack, panicValue, showPanicValue := prettyStackInput(rvr)
 	s := prettyStack{}
-	out, err := s.parse(debugStack, rvr)
+	out, err := s.parseWithOptions(debugStack, panicValue, showPanicValue)
 	if err == nil {
 		_, _ = os.Stderr.Write(out)
 	} else {
@@ -25,13 +26,19 @@ func PrintPrettyStack(rvr interface{}) {
 }
 
 func (s prettyStack) parse(debugStack []byte, rvr interface{}) ([]byte, error) {
+	return s.parseWithOptions(debugStack, rvr, true)
+}
+
+func (s prettyStack) parseWithOptions(debugStack []byte, rvr interface{}, showPanicValue bool) ([]byte, error) {
 	var err error
 	buf := &bytes.Buffer{}
 
 	cW(buf, false, bRed, "\n")
-	cW(buf, true, bCyan, " panic: ")
-	cW(buf, true, bBlue, "%v", rvr)
-	cW(buf, false, bWhite, "\n \n")
+	if showPanicValue {
+		cW(buf, true, bCyan, " panic: ")
+		cW(buf, true, bBlue, "%v", rvr)
+		cW(buf, false, bWhite, "\n \n")
+	}
 
 	// process debug stack info
 	stack := strings.Split(string(debugStack), "\n")
@@ -66,6 +73,35 @@ func (s prettyStack) parse(debugStack []byte, rvr interface{}) ([]byte, error) {
 		}
 	}
 	return buf.Bytes(), nil
+}
+
+func prettyStackInput(rvr interface{}) ([]byte, interface{}, bool) {
+	switch v := rvr.(type) {
+	case []byte:
+		if looksLikeStackTrace(v) {
+			return v, nil, false
+		}
+		return debug.Stack(), readableBytes(v), true
+	case string:
+		if looksLikeStackTrace([]byte(v)) {
+			return []byte(v), nil, false
+		}
+		return debug.Stack(), v, true
+	default:
+		return debug.Stack(), rvr, true
+	}
+}
+
+func looksLikeStackTrace(stack []byte) bool {
+	return bytes.Contains(stack, []byte("goroutine ")) && bytes.Contains(stack, []byte(".go:"))
+}
+
+func readableBytes(value []byte) interface{} {
+	if utf8.Valid(value) {
+		return string(value)
+	}
+
+	return fmt.Sprintf("%x", value)
 }
 
 func (s prettyStack) decorateLine(line string, useColor bool, num int) (string, error) {

--- a/logs/pretty_test.go
+++ b/logs/pretty_test.go
@@ -110,3 +110,22 @@ func TestPrintPrettyStack_DoesNotPanic(t *testing.T) {
 		PrintPrettyStack(nil)
 	})
 }
+
+func TestPrintPrettyStack_StackBytesHideRawByteSlice(t *testing.T) {
+	fakeStack := []byte(`goroutine 1 [running]:
+runtime/debug.Stack()
+	/usr/local/go/src/runtime/debug/stack.go:24 +0x5e
+main.doSomething()
+	/app/main.go:42 +0x1a
+main.main()
+	/app/main.go:10 +0x25
+`)
+
+	_, stderr := captureStandardStreams(t, func() {
+		PrintPrettyStack(fakeStack)
+	})
+
+	assert.NotContains(t, stderr, "panic: [")
+	assert.NotContains(t, stderr, "[103 111")
+	assert.Contains(t, stderr, "main.go")
+}

--- a/middleware/recoverer.go
+++ b/middleware/recoverer.go
@@ -59,10 +59,6 @@ func PrintPrettyStack(rvr interface{}) {
 type prettyStack struct {
 }
 
-func (s prettyStack) parse(debugStack []byte, rvr interface{}) ([]byte, error) {
-	return s.parseWithOptions(debugStack, rvr, true)
-}
-
 func (s prettyStack) parseWithOptions(debugStack []byte, rvr interface{}, showPanicValue bool) ([]byte, error) {
 	var err error
 

--- a/middleware/recoverer.go
+++ b/middleware/recoverer.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"runtime/debug"
 	"strings"
+	"unicode/utf8"
 )
 
 // Recoverer is a middleware that recovers from panics, logs the panic (and a
@@ -44,9 +45,9 @@ func (s *System) Recoverer(next http.Handler) http.Handler {
 }
 
 func PrintPrettyStack(rvr interface{}) {
-	debugStack := debug.Stack()
+	debugStack, panicValue, showPanicValue := prettyStackInput(rvr)
 	s := prettyStack{}
-	out, err := s.parse(debugStack, rvr)
+	out, err := s.parseWithOptions(debugStack, panicValue, showPanicValue)
 	if err == nil {
 		_, _ = os.Stderr.Write(out)
 	} else {
@@ -59,14 +60,20 @@ type prettyStack struct {
 }
 
 func (s prettyStack) parse(debugStack []byte, rvr interface{}) ([]byte, error) {
+	return s.parseWithOptions(debugStack, rvr, true)
+}
+
+func (s prettyStack) parseWithOptions(debugStack []byte, rvr interface{}, showPanicValue bool) ([]byte, error) {
 	var err error
 
 	buf := &bytes.Buffer{}
 
 	cW(buf, false, bRed, "\n")
-	cW(buf, true, bCyan, " panic: ")
-	cW(buf, true, bBlue, "%v", rvr)
-	cW(buf, false, bWhite, "\n \n")
+	if showPanicValue {
+		cW(buf, true, bCyan, " panic: ")
+		cW(buf, true, bBlue, "%v", rvr)
+		cW(buf, false, bWhite, "\n \n")
+	}
 
 	// process debug stack info
 	stack := strings.Split(string(debugStack), "\n")
@@ -101,6 +108,35 @@ func (s prettyStack) parse(debugStack []byte, rvr interface{}) ([]byte, error) {
 		}
 	}
 	return buf.Bytes(), nil
+}
+
+func prettyStackInput(rvr interface{}) ([]byte, interface{}, bool) {
+	switch v := rvr.(type) {
+	case []byte:
+		if looksLikeStackTrace(v) {
+			return v, nil, false
+		}
+		return debug.Stack(), readableBytes(v), true
+	case string:
+		if looksLikeStackTrace([]byte(v)) {
+			return []byte(v), nil, false
+		}
+		return debug.Stack(), v, true
+	default:
+		return debug.Stack(), rvr, true
+	}
+}
+
+func looksLikeStackTrace(stack []byte) bool {
+	return bytes.Contains(stack, []byte("goroutine ")) && bytes.Contains(stack, []byte(".go:"))
+}
+
+func readableBytes(value []byte) interface{} {
+	if utf8.Valid(value) {
+		return string(value)
+	}
+
+	return fmt.Sprintf("%x", value)
 }
 
 func (s prettyStack) bugParse(debugStack []byte, rvr interface{}) (BugFixesSend, error) {

--- a/middleware/recoverer_test.go
+++ b/middleware/recoverer_test.go
@@ -1,13 +1,41 @@
 package middleware_test
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/bugfixes/go-bugfixes/middleware"
 	"github.com/stretchr/testify/assert"
 )
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	origStderr := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stderr pipe: %v", err)
+	}
+
+	os.Stderr = writer
+	defer func() {
+		os.Stderr = origStderr
+	}()
+
+	fn()
+
+	_ = writer.Close()
+
+	stderr, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+
+	return string(stderr)
+}
 
 func TestRecoverer_PanicReturns500(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -118,4 +146,23 @@ func TestRecoverer_SystemMethod(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 	})
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+func TestPrintPrettyStack_StackBytesHideRawByteSlice(t *testing.T) {
+	fakeStack := []byte(`goroutine 1 [running]:
+runtime/debug.Stack()
+	/usr/local/go/src/runtime/debug/stack.go:24 +0x5e
+main.doSomething()
+	/app/main.go:42 +0x1a
+main.main()
+	/app/main.go:10 +0x25
+`)
+
+	stderr := captureStderr(t, func() {
+		middleware.PrintPrettyStack(fakeStack)
+	})
+
+	assert.NotContains(t, stderr, "panic: [")
+	assert.NotContains(t, stderr, "[103 111")
+	assert.Contains(t, stderr, "main.go")
 }


### PR DESCRIPTION
## Summary
- detect when pretty stack printers receive a captured stack trace and reuse it instead of rendering the raw `[]byte` payload as `panic: [103 ...]`
- keep non-stack byte slice output readable by decoding valid UTF-8 before formatting it for stderr
- add regression coverage in logs and middleware for stack-byte inputs

## Testing
- go test ./logs ./middleware
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bugfixes/go-bugfixes/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
