### PR TITLE
Add security headers middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,15 +141,15 @@ system.SetSecure(true)
 
 // Allow iframes on main site
 system.AddSecureConfig("example.com", bugfixes.SecureConfig{
-	XFrameOptions: bugfixes.StrPtr("SAMEORIGIN"),
-	CSP:          bugfixes.StrPtr("default-src 'self'; script-src 'self' 'unsafe-inline'"),
+	XFrameOptions: bugfixes.Ptr("SAMEORIGIN"),
+	CSP:          bugfixes.Ptr("default-src 'self'; script-src 'self' 'unsafe-inline'"),
 })
 
 // Stricter CSP for API subdomain
 system.AddSecureConfig("api.example.com", bugfixes.SecureConfig{
-	XFrameOptions: bugfixes.StrPtr("DENY"),
-	CSP:          bugfixes.StrPtr("default-src 'self'"),
-	HSTSMaxAge:   bugfixes.DurationPtr(730 * 24 * time.Hour), // 2 years
+	XFrameOptions: bugfixes.Ptr("DENY"),
+	CSP:          bugfixes.Ptr("default-src 'self'"),
+	HSTSMaxAge:   bugfixes.Ptr(730 * 24 * time.Hour), // 2 years
 })
 
 system.AddMiddleware(system.Secure)
@@ -164,10 +164,10 @@ Configure HSTS with additional options:
 import "time"
 
 system.AddSecureConfig("example.com", bugfixes.SecureConfig{
-	HSTSEnabled:            bugfixes.BoolPtr(true),
-	HSTSMaxAge:            bugfixes.DurationPtr(180 * 24 * time.Hour), // 6 months
-	HSTSIncludeSubdomains: bugfixes.BoolPtr(true),
-	HSTSPreload:           bugfixes.BoolPtr(true),
+	HSTSEnabled:            bugfixes.Ptr(true),
+	HSTSMaxAge:            bugfixes.Ptr(180 * 24 * time.Hour), // 6 months
+	HSTSIncludeSubdomains: bugfixes.Ptr(true),
+	HSTSPreload:           bugfixes.Ptr(true),
 })
 ```
 
@@ -177,9 +177,9 @@ Set empty string or `false` to disable individual headers:
 
 ```go
 system.AddSecureConfig("example.com", bugfixes.SecureConfig{
-	XFrameOptions:       bugfixes.StrPtr(""),      // removes X-Frame-Options
-	XContentTypeOptions: bugfixes.BoolPtr(false), // removes X-Content-Type-Options
-	XXSSProtection:      bugfixes.StrPtr(""),      // removes X-XSS-Protection
+	XFrameOptions:       bugfixes.Ptr(""),      // removes X-Frame-Options
+	XContentTypeOptions: bugfixes.Ptr(false), // removes X-Content-Type-Options
+	XXSSProtection:      bugfixes.Ptr(""),      // removes X-XSS-Protection
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ system.AddSecureConfig("example.com", bugfixes.SecureConfig{
 system.AddSecureConfig("api.example.com", bugfixes.SecureConfig{
 	XFrameOptions: "DENY",
 	CSP:           "default-src 'self'",
+	HSTSEnabled:   true,
 	HSTSMaxAge:    730 * 24 * time.Hour, // 2 years
 })
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,97 @@ system.AddMiddleware(
 handler := system.Handler(mux)
 ```
 
+### CORS
+
+Enable CORS with domain-specific configuration:
+
+```go
+system := bugfixes.NewMiddleware()
+system.AddAllowedOrigins("https://example.com", "https://app.example.com")
+system.AddAllowedMethods("GET", "POST", "PUT", "DELETE")
+system.AddAllowedHeaders("Authorization", "X-Custom-Header")
+system.AddMiddleware(system.CORS)
+handler := system.Handler(mux)
+```
+
+Multiple domains are supported. Requests from unlisted origins return `403 Forbidden`.
+
+### Security Headers
+
+Enable security headers with production-safe defaults:
+
+```go
+system := bugfixes.NewMiddleware()
+system.SetSecure(true)
+system.AddMiddleware(system.Secure)
+handler := system.Handler(mux)
+```
+
+This sets the following headers by default:
+
+| Header | Value |
+|--------|-------|
+| X-Frame-Options | DENY |
+| X-Content-Type-Options | nosniff |
+| X-XSS-Protection | 1; mode=block |
+| Strict-Transport-Security | max-age=31536000; includeSubDomains |
+| Content-Security-Policy | default-src 'self' |
+| Referrer-Policy | strict-origin-when-cross-origin |
+
+#### Domain-Specific Configuration
+
+Override defaults per-domain:
+
+```go
+import "time"
+
+system := bugfixes.NewMiddleware()
+system.SetSecure(true)
+
+// Allow iframes on main site
+system.AddSecureConfig("example.com", bugfixes.SecureConfig{
+	XFrameOptions: "SAMEORIGIN",
+	CSP:           "default-src 'self'; script-src 'self' 'unsafe-inline'",
+})
+
+// Stricter CSP for API subdomain
+system.AddSecureConfig("api.example.com", bugfixes.SecureConfig{
+	XFrameOptions: "DENY",
+	CSP:           "default-src 'self'",
+	HSTSMaxAge:    730 * 24 * time.Hour, // 2 years
+})
+
+system.AddMiddleware(system.Secure)
+handler := system.Handler(mux)
+```
+
+#### HSTS Options
+
+Configure HSTS with additional options:
+
+```go
+import "time"
+
+system.AddSecureConfig("example.com", bugfixes.SecureConfig{
+	HSTSEnabled:            true,
+	HSTSMaxAge:            180 * 24 * time.Hour, // 6 months
+	HSTSIncludeSubdomains: true,
+	HSTSPreload:           true,
+})
+```
+
+#### Disabling Headers
+
+Set empty string or `false` to disable individual headers:
+
+```go
+system.AddSecureConfig("example.com", bugfixes.SecureConfig{
+	XFrameOptions:        "",    // removes X-Frame-Options
+	XContentTypeOptions:  false, // removes X-Content-Type-Options
+	XXSSProtection:       "",    // removes X-XSS-Protection
+})
+```
+
 ## Development
 
 Common repo tasks:

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ This sets the following headers by default:
 
 #### Domain-Specific Configuration
 
-Override defaults per-domain:
+Override defaults per-domain. Only set the fields you want to change; unset fields use defaults:
 
 ```go
 import "time"
@@ -141,16 +141,15 @@ system.SetSecure(true)
 
 // Allow iframes on main site
 system.AddSecureConfig("example.com", bugfixes.SecureConfig{
-	XFrameOptions: "SAMEORIGIN",
-	CSP:           "default-src 'self'; script-src 'self' 'unsafe-inline'",
+	XFrameOptions: bugfixes.StrPtr("SAMEORIGIN"),
+	CSP:          bugfixes.StrPtr("default-src 'self'; script-src 'self' 'unsafe-inline'"),
 })
 
 // Stricter CSP for API subdomain
 system.AddSecureConfig("api.example.com", bugfixes.SecureConfig{
-	XFrameOptions: "DENY",
-	CSP:           "default-src 'self'",
-	HSTSEnabled:   true,
-	HSTSMaxAge:    730 * 24 * time.Hour, // 2 years
+	XFrameOptions: bugfixes.StrPtr("DENY"),
+	CSP:          bugfixes.StrPtr("default-src 'self'"),
+	HSTSMaxAge:   bugfixes.DurationPtr(730 * 24 * time.Hour), // 2 years
 })
 
 system.AddMiddleware(system.Secure)
@@ -165,10 +164,10 @@ Configure HSTS with additional options:
 import "time"
 
 system.AddSecureConfig("example.com", bugfixes.SecureConfig{
-	HSTSEnabled:            true,
-	HSTSMaxAge:            180 * 24 * time.Hour, // 6 months
-	HSTSIncludeSubdomains: true,
-	HSTSPreload:           true,
+	HSTSEnabled:            bugfixes.BoolPtr(true),
+	HSTSMaxAge:            bugfixes.DurationPtr(180 * 24 * time.Hour), // 6 months
+	HSTSIncludeSubdomains: bugfixes.BoolPtr(true),
+	HSTSPreload:           bugfixes.BoolPtr(true),
 })
 ```
 
@@ -178,9 +177,9 @@ Set empty string or `false` to disable individual headers:
 
 ```go
 system.AddSecureConfig("example.com", bugfixes.SecureConfig{
-	XFrameOptions:        "",    // removes X-Frame-Options
-	XContentTypeOptions:  false, // removes X-Content-Type-Options
-	XXSSProtection:       "",    // removes X-XSS-Protection
+	XFrameOptions:       bugfixes.StrPtr(""),      // removes X-Frame-Options
+	XContentTypeOptions: bugfixes.BoolPtr(false), // removes X-Content-Type-Options
+	XXSSProtection:      bugfixes.StrPtr(""),      // removes X-XSS-Protection
 })
 ```
 

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -22,20 +22,20 @@ type SecureConfig struct {
 }
 
 var DefaultSecureConfig = SecureConfig{
-	XFrameOptions:         StrPtr("DENY"),
-	XContentTypeOptions:   BoolPtr(true),
-	XXSSProtection:        StrPtr("1; mode=block"),
-	HSTSEnabled:           BoolPtr(true),
-	HSTSMaxAge:            DurationPtr(365 * 24 * time.Hour),
-	HSTSIncludeSubdomains: BoolPtr(true),
-	HSTSPreload:           BoolPtr(false),
-	ReferrerPolicy:        StrPtr("strict-origin-when-cross-origin"),
-	CSP:                   StrPtr("default-src 'self'"),
+	XFrameOptions:         Ptr("DENY"),
+	XContentTypeOptions:   Ptr(true),
+	XXSSProtection:        Ptr("1; mode=block"),
+	HSTSEnabled:           Ptr(true),
+	HSTSMaxAge:            Ptr(365 * 24 * time.Hour),
+	HSTSIncludeSubdomains: Ptr(true),
+	HSTSPreload:           Ptr(false),
+	ReferrerPolicy:        Ptr("strict-origin-when-cross-origin"),
+	CSP:                   Ptr("default-src 'self'"),
 }
 
-func StrPtr(s string) *string                    { return &s }
-func BoolPtr(b bool) *bool                       { return &b }
-func DurationPtr(d time.Duration) *time.Duration { return &d }
+func Ptr[T any](v T) *T {
+	return &v
+}
 
 type System struct {
 	mu sync.RWMutex

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -3,9 +3,34 @@ package middleware
 import (
 	"net/http"
 	"sync"
+	"time"
 
 	bugfixes "github.com/bugfixes/go-bugfixes"
 )
+
+type SecureConfig struct {
+	XFrameOptions         string
+	XContentTypeOptions   bool
+	XXSSProtection        string
+	HSTSEnabled           bool
+	HSTSMaxAge            time.Duration
+	HSTSIncludeSubdomains bool
+	HSTSPreload           bool
+	CSP                   string
+	ReferrerPolicy        string
+	PermissionsPolicy     string
+}
+
+var DefaultSecureConfig = SecureConfig{
+	XFrameOptions:         "DENY",
+	XContentTypeOptions:   true,
+	XXSSProtection:        "1; mode=block",
+	HSTSEnabled:           true,
+	HSTSMaxAge:            365 * 24 * time.Hour,
+	HSTSIncludeSubdomains: true,
+	ReferrerPolicy:        "strict-origin-when-cross-origin",
+	CSP:                   "default-src 'self'",
+}
 
 type System struct {
 	mu sync.RWMutex
@@ -22,6 +47,10 @@ type System struct {
 	AllowedOrigins []string
 	AllowedHeaders []string
 	AllowedMethods []string
+
+	// Secure headers
+	SecureEnabled bool
+	SecureConfigs map[string]SecureConfig
 }
 
 func NewMiddleware() *System {

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -9,28 +9,33 @@ import (
 )
 
 type SecureConfig struct {
-	XFrameOptions         string
-	XContentTypeOptions   bool
-	XXSSProtection        string
-	HSTSEnabled           bool
-	HSTSMaxAge            time.Duration
-	HSTSIncludeSubdomains bool
-	HSTSPreload           bool
-	CSP                   string
-	ReferrerPolicy        string
-	PermissionsPolicy     string
+	XFrameOptions         *string
+	XContentTypeOptions   *bool
+	XXSSProtection        *string
+	HSTSEnabled           *bool
+	HSTSMaxAge            *time.Duration
+	HSTSIncludeSubdomains *bool
+	HSTSPreload           *bool
+	CSP                   *string
+	ReferrerPolicy        *string
+	PermissionsPolicy     *string
 }
 
 var DefaultSecureConfig = SecureConfig{
-	XFrameOptions:         "DENY",
-	XContentTypeOptions:   true,
-	XXSSProtection:        "1; mode=block",
-	HSTSEnabled:           true,
-	HSTSMaxAge:            365 * 24 * time.Hour,
-	HSTSIncludeSubdomains: true,
-	ReferrerPolicy:        "strict-origin-when-cross-origin",
-	CSP:                   "default-src 'self'",
+	XFrameOptions:         StrPtr("DENY"),
+	XContentTypeOptions:   BoolPtr(true),
+	XXSSProtection:        StrPtr("1; mode=block"),
+	HSTSEnabled:           BoolPtr(true),
+	HSTSMaxAge:            DurationPtr(365 * 24 * time.Hour),
+	HSTSIncludeSubdomains: BoolPtr(true),
+	HSTSPreload:           BoolPtr(false),
+	ReferrerPolicy:        StrPtr("strict-origin-when-cross-origin"),
+	CSP:                   StrPtr("default-src 'self'"),
 }
+
+func StrPtr(s string) *string                    { return &s }
+func BoolPtr(b bool) *bool                       { return &b }
+func DurationPtr(d time.Duration) *time.Duration { return &d }
 
 type System struct {
 	mu sync.RWMutex

--- a/middleware/secure.go
+++ b/middleware/secure.go
@@ -1,0 +1,91 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func (s *System) SetSecure(enabled bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.SecureEnabled = enabled
+}
+
+func (s *System) SetSecureConfig(domain string, config SecureConfig) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.SecureConfigs == nil {
+		s.SecureConfigs = make(map[string]SecureConfig)
+	}
+	s.SecureConfigs[domain] = config
+}
+
+func (s *System) AddSecureConfig(domain string, config SecureConfig) {
+	s.SetSecureConfig(domain, config)
+}
+
+func (s *System) isSecureEnabled() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.SecureEnabled
+}
+
+func (s *System) getSecureConfig(domain string) SecureConfig {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if cfg, ok := s.SecureConfigs[domain]; ok {
+		return cfg
+	}
+
+	return DefaultSecureConfig
+}
+
+func (s *System) Secure(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !s.isSecureEnabled() {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		domain := r.Host
+		config := s.getSecureConfig(domain)
+
+		if config.XFrameOptions != "" {
+			w.Header().Set("X-Frame-Options", config.XFrameOptions)
+		}
+
+		if config.XContentTypeOptions {
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+		}
+
+		if config.XXSSProtection != "" {
+			w.Header().Set("X-XSS-Protection", config.XXSSProtection)
+		}
+
+		if config.HSTSEnabled {
+			hsts := fmt.Sprintf("max-age=%d", int(config.HSTSMaxAge.Seconds()))
+			if config.HSTSIncludeSubdomains {
+				hsts += "; includeSubDomains"
+			}
+			if config.HSTSPreload {
+				hsts += "; preload"
+			}
+			w.Header().Set("Strict-Transport-Security", hsts)
+		}
+
+		if config.CSP != "" {
+			w.Header().Set("Content-Security-Policy", config.CSP)
+		}
+
+		if config.ReferrerPolicy != "" {
+			w.Header().Set("Referrer-Policy", config.ReferrerPolicy)
+		}
+
+		if config.PermissionsPolicy != "" {
+			w.Header().Set("Permissions-Policy", config.PermissionsPolicy)
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/middleware/secure.go
+++ b/middleware/secure.go
@@ -34,11 +34,42 @@ func (s *System) getSecureConfig(domain string) SecureConfig {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	if cfg, ok := s.SecureConfigs[domain]; ok {
-		return cfg
+	config := DefaultSecureConfig
+
+	if domainCfg, ok := s.SecureConfigs[domain]; ok {
+		if domainCfg.XFrameOptions != nil {
+			config.XFrameOptions = domainCfg.XFrameOptions
+		}
+		if domainCfg.XContentTypeOptions != nil {
+			config.XContentTypeOptions = domainCfg.XContentTypeOptions
+		}
+		if domainCfg.XXSSProtection != nil {
+			config.XXSSProtection = domainCfg.XXSSProtection
+		}
+		if domainCfg.HSTSEnabled != nil {
+			config.HSTSEnabled = domainCfg.HSTSEnabled
+		}
+		if domainCfg.HSTSMaxAge != nil {
+			config.HSTSMaxAge = domainCfg.HSTSMaxAge
+		}
+		if domainCfg.HSTSIncludeSubdomains != nil {
+			config.HSTSIncludeSubdomains = domainCfg.HSTSIncludeSubdomains
+		}
+		if domainCfg.HSTSPreload != nil {
+			config.HSTSPreload = domainCfg.HSTSPreload
+		}
+		if domainCfg.CSP != nil {
+			config.CSP = domainCfg.CSP
+		}
+		if domainCfg.ReferrerPolicy != nil {
+			config.ReferrerPolicy = domainCfg.ReferrerPolicy
+		}
+		if domainCfg.PermissionsPolicy != nil {
+			config.PermissionsPolicy = domainCfg.PermissionsPolicy
+		}
 	}
 
-	return DefaultSecureConfig
+	return config
 }
 
 func (s *System) Secure(next http.Handler) http.Handler {
@@ -51,39 +82,39 @@ func (s *System) Secure(next http.Handler) http.Handler {
 		domain := r.Host
 		config := s.getSecureConfig(domain)
 
-		if config.XFrameOptions != "" {
-			w.Header().Set("X-Frame-Options", config.XFrameOptions)
+		if config.XFrameOptions != nil && *config.XFrameOptions != "" {
+			w.Header().Set("X-Frame-Options", *config.XFrameOptions)
 		}
 
-		if config.XContentTypeOptions {
+		if config.XContentTypeOptions != nil && *config.XContentTypeOptions {
 			w.Header().Set("X-Content-Type-Options", "nosniff")
 		}
 
-		if config.XXSSProtection != "" {
-			w.Header().Set("X-XSS-Protection", config.XXSSProtection)
+		if config.XXSSProtection != nil && *config.XXSSProtection != "" {
+			w.Header().Set("X-XSS-Protection", *config.XXSSProtection)
 		}
 
-		if config.HSTSEnabled {
-			hsts := fmt.Sprintf("max-age=%d", int(config.HSTSMaxAge.Seconds()))
-			if config.HSTSIncludeSubdomains {
+		if config.HSTSEnabled != nil && *config.HSTSEnabled {
+			hsts := fmt.Sprintf("max-age=%d", int((*config.HSTSMaxAge).Seconds()))
+			if config.HSTSIncludeSubdomains != nil && *config.HSTSIncludeSubdomains {
 				hsts += "; includeSubDomains"
 			}
-			if config.HSTSPreload {
+			if config.HSTSPreload != nil && *config.HSTSPreload {
 				hsts += "; preload"
 			}
 			w.Header().Set("Strict-Transport-Security", hsts)
 		}
 
-		if config.CSP != "" {
-			w.Header().Set("Content-Security-Policy", config.CSP)
+		if config.CSP != nil && *config.CSP != "" {
+			w.Header().Set("Content-Security-Policy", *config.CSP)
 		}
 
-		if config.ReferrerPolicy != "" {
-			w.Header().Set("Referrer-Policy", config.ReferrerPolicy)
+		if config.ReferrerPolicy != nil && *config.ReferrerPolicy != "" {
+			w.Header().Set("Referrer-Policy", *config.ReferrerPolicy)
 		}
 
-		if config.PermissionsPolicy != "" {
-			w.Header().Set("Permissions-Policy", config.PermissionsPolicy)
+		if config.PermissionsPolicy != nil && *config.PermissionsPolicy != "" {
+			w.Header().Set("Permissions-Policy", *config.PermissionsPolicy)
 		}
 
 		next.ServeHTTP(w, r)

--- a/middleware/secure.go
+++ b/middleware/secure.go
@@ -95,7 +95,7 @@ func (s *System) Secure(next http.Handler) http.Handler {
 		}
 
 		if config.HSTSEnabled != nil && *config.HSTSEnabled {
-			hsts := fmt.Sprintf("max-age=%d", int((*config.HSTSMaxAge).Seconds()))
+			hsts := fmt.Sprintf("max-age=%d", int(config.HSTSMaxAge.Seconds()))
 			if config.HSTSIncludeSubdomains != nil && *config.HSTSIncludeSubdomains {
 				hsts += "; includeSubDomains"
 			}

--- a/middleware/secure_test.go
+++ b/middleware/secure_test.go
@@ -52,10 +52,10 @@ func TestSecure_CustomConfig_OverridesDefaults(t *testing.T) {
 	s := middleware.NewMiddleware()
 	s.SetSecure(true)
 	s.AddSecureConfig("example.com", middleware.SecureConfig{
-		XFrameOptions:       "SAMEORIGIN",
-		XContentTypeOptions: false,
-		CSP:                 "default-src 'self'; script-src 'self' 'unsafe-inline'",
-		ReferrerPolicy:      "no-referrer",
+		XFrameOptions:       middleware.StrPtr("SAMEORIGIN"),
+		XContentTypeOptions: middleware.BoolPtr(false),
+		CSP:                 middleware.StrPtr("default-src 'self'; script-src 'self' 'unsafe-inline'"),
+		ReferrerPolicy:      middleware.StrPtr("no-referrer"),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -76,13 +76,13 @@ func TestSecure_DomainSpecificConfigs(t *testing.T) {
 	s.SetSecure(true)
 
 	s.AddSecureConfig("example.com", middleware.SecureConfig{
-		XFrameOptions: "SAMEORIGIN",
-		CSP:           "default-src 'self'",
+		XFrameOptions: middleware.StrPtr("SAMEORIGIN"),
+		CSP:           middleware.StrPtr("default-src 'self'"),
 	})
 
 	s.AddSecureConfig("api.example.com", middleware.SecureConfig{
-		XFrameOptions: "DENY",
-		CSP:           "default-src 'self'; connect-src 'self' https://api.example.com",
+		XFrameOptions: middleware.StrPtr("DENY"),
+		CSP:           middleware.StrPtr("default-src 'self'; connect-src 'self' https://api.example.com"),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -131,10 +131,10 @@ func TestSecure_HSTS_AllOptions(t *testing.T) {
 	s := middleware.NewMiddleware()
 	s.SetSecure(true)
 	s.AddSecureConfig("example.com", middleware.SecureConfig{
-		HSTSEnabled:           true,
-		HSTSMaxAge:            180 * 24 * time.Hour,
-		HSTSIncludeSubdomains: true,
-		HSTSPreload:           true,
+		HSTSEnabled:           middleware.BoolPtr(true),
+		HSTSMaxAge:            middleware.DurationPtr(180 * 24 * time.Hour),
+		HSTSIncludeSubdomains: middleware.BoolPtr(true),
+		HSTSPreload:           middleware.BoolPtr(true),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -154,7 +154,7 @@ func TestSecure_HSTS_Disabled(t *testing.T) {
 	s := middleware.NewMiddleware()
 	s.SetSecure(true)
 	s.AddSecureConfig("example.com", middleware.SecureConfig{
-		HSTSEnabled: false,
+		HSTSEnabled: middleware.BoolPtr(false),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -171,9 +171,9 @@ func TestSecure_HSTS_NoSubdomains(t *testing.T) {
 	s := middleware.NewMiddleware()
 	s.SetSecure(true)
 	s.AddSecureConfig("example.com", middleware.SecureConfig{
-		HSTSEnabled:           true,
-		HSTSMaxAge:            365 * 24 * time.Hour,
-		HSTSIncludeSubdomains: false,
+		HSTSEnabled:           middleware.BoolPtr(true),
+		HSTSMaxAge:            middleware.DurationPtr(365 * 24 * time.Hour),
+		HSTSIncludeSubdomains: middleware.BoolPtr(false),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -191,7 +191,7 @@ func TestSecure_PermissionsPolicy(t *testing.T) {
 	s := middleware.NewMiddleware()
 	s.SetSecure(true)
 	s.AddSecureConfig("example.com", middleware.SecureConfig{
-		PermissionsPolicy: "geolocation=(self), microphone=()",
+		PermissionsPolicy: middleware.StrPtr("geolocation=(self), microphone=()"),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -208,7 +208,7 @@ func TestSecure_XXSSProtection_Disabled(t *testing.T) {
 	s := middleware.NewMiddleware()
 	s.SetSecure(true)
 	s.AddSecureConfig("example.com", middleware.SecureConfig{
-		XXSSProtection: "",
+		XXSSProtection: middleware.StrPtr(""),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -225,7 +225,7 @@ func TestSecure_XFrameOptions_AllowFrom(t *testing.T) {
 	s := middleware.NewMiddleware()
 	s.SetSecure(true)
 	s.AddSecureConfig("example.com", middleware.SecureConfig{
-		XFrameOptions: "ALLOW-FROM https://trusted.com",
+		XFrameOptions: middleware.StrPtr("ALLOW-FROM https://trusted.com"),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -279,11 +279,11 @@ func TestSecure_AppendSecureConfigs(t *testing.T) {
 	s.SetSecure(true)
 
 	s.AddSecureConfig("one.com", middleware.SecureConfig{
-		XFrameOptions: "SAMEORIGIN",
+		XFrameOptions: middleware.StrPtr("SAMEORIGIN"),
 	})
 
 	s.AddSecureConfig("two.com", middleware.SecureConfig{
-		XFrameOptions: "DENY",
+		XFrameOptions: middleware.StrPtr("DENY"),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -306,11 +306,11 @@ func TestSetSecureConfig_UpdatesExisting(t *testing.T) {
 	s.SetSecure(true)
 
 	s.SetSecureConfig("example.com", middleware.SecureConfig{
-		XFrameOptions: "SAMEORIGIN",
+		XFrameOptions: middleware.StrPtr("SAMEORIGIN"),
 	})
 
 	s.SetSecureConfig("example.com", middleware.SecureConfig{
-		XFrameOptions: "DENY",
+		XFrameOptions: middleware.StrPtr("DENY"),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -328,7 +328,7 @@ func TestSecureConfig_WithHostPort(t *testing.T) {
 	s.SetSecure(true)
 
 	s.AddSecureConfig("example.com:8080", middleware.SecureConfig{
-		XFrameOptions: "SAMEORIGIN",
+		XFrameOptions: middleware.StrPtr("SAMEORIGIN"),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -360,7 +360,7 @@ func TestSecure_CSPWithReportURI(t *testing.T) {
 	s := middleware.NewMiddleware()
 	s.SetSecure(true)
 	s.AddSecureConfig("example.com", middleware.SecureConfig{
-		CSP: "default-src 'self'; report-uri /csp-report",
+		CSP: middleware.StrPtr("default-src 'self'; report-uri /csp-report"),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -392,7 +392,7 @@ func TestSecure_ReferrerPolicy_Values(t *testing.T) {
 			s := middleware.NewMiddleware()
 			s.SetSecure(true)
 			s.AddSecureConfig("example.com", middleware.SecureConfig{
-				ReferrerPolicy: tc.policy,
+				ReferrerPolicy: middleware.StrPtr(tc.policy),
 			})
 
 			handler := s.Secure(newOKHandler())
@@ -411,7 +411,7 @@ func TestSecure_XContentTypeOptions_NosniffOnly(t *testing.T) {
 	s := middleware.NewMiddleware()
 	s.SetSecure(true)
 	s.AddSecureConfig("example.com", middleware.SecureConfig{
-		XContentTypeOptions: true,
+		XContentTypeOptions: middleware.BoolPtr(true),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -427,14 +427,36 @@ func TestSecure_XContentTypeOptions_NosniffOnly(t *testing.T) {
 func TestDefaultSecureConfig_Values(t *testing.T) {
 	cfg := middleware.DefaultSecureConfig
 
-	assert.Equal(t, "DENY", cfg.XFrameOptions)
-	assert.True(t, cfg.XContentTypeOptions)
-	assert.Equal(t, "1; mode=block", cfg.XXSSProtection)
-	assert.True(t, cfg.HSTSEnabled)
-	assert.Equal(t, 365*24*time.Hour, cfg.HSTSMaxAge)
-	assert.True(t, cfg.HSTSIncludeSubdomains)
-	assert.False(t, cfg.HSTSPreload)
-	assert.Equal(t, "default-src 'self'", cfg.CSP)
-	assert.Equal(t, "strict-origin-when-cross-origin", cfg.ReferrerPolicy)
-	assert.Empty(t, cfg.PermissionsPolicy)
+	assert.Equal(t, "DENY", *cfg.XFrameOptions)
+	assert.True(t, *cfg.XContentTypeOptions)
+	assert.Equal(t, "1; mode=block", *cfg.XXSSProtection)
+	assert.True(t, *cfg.HSTSEnabled)
+	assert.Equal(t, 365*24*time.Hour, *cfg.HSTSMaxAge)
+	assert.True(t, *cfg.HSTSIncludeSubdomains)
+	assert.False(t, *cfg.HSTSPreload)
+	assert.Equal(t, "default-src 'self'", *cfg.CSP)
+	assert.Equal(t, "strict-origin-when-cross-origin", *cfg.ReferrerPolicy)
+	assert.Nil(t, cfg.PermissionsPolicy)
+}
+
+func TestSecure_PartialConfig_MergesWithDefaults(t *testing.T) {
+	s := middleware.NewMiddleware()
+	s.SetSecure(true)
+
+	s.AddSecureConfig("example.com", middleware.SecureConfig{
+		XFrameOptions: middleware.StrPtr("SAMEORIGIN"),
+	})
+
+	handler := s.Secure(newOKHandler())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "example.com"
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, "SAMEORIGIN", rr.Header().Get("X-Frame-Options"))
+	assert.Equal(t, "nosniff", rr.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t, "max-age=31536000; includeSubDomains", rr.Header().Get("Strict-Transport-Security"))
+	assert.Equal(t, "default-src 'self'", rr.Header().Get("Content-Security-Policy"))
+	assert.Equal(t, "strict-origin-when-cross-origin", rr.Header().Get("Referrer-Policy"))
 }

--- a/middleware/secure_test.go
+++ b/middleware/secure_test.go
@@ -1,0 +1,440 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/bugfixes/go-bugfixes/middleware"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSecure_DefaultConfig_SetsAllHeaders(t *testing.T) {
+	s := middleware.NewMiddleware()
+	s.SetSecure(true)
+
+	handler := s.Secure(newOKHandler())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "example.com"
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "DENY", rr.Header().Get("X-Frame-Options"))
+	assert.Equal(t, "nosniff", rr.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t, "1; mode=block", rr.Header().Get("X-XSS-Protection"))
+	assert.Equal(t, "max-age=31536000; includeSubDomains", rr.Header().Get("Strict-Transport-Security"))
+	assert.Equal(t, "default-src 'self'", rr.Header().Get("Content-Security-Policy"))
+	assert.Equal(t, "strict-origin-when-cross-origin", rr.Header().Get("Referrer-Policy"))
+}
+
+func TestSecure_Disabled_SetsNoHeaders(t *testing.T) {
+	s := middleware.NewMiddleware()
+	s.SetSecure(false)
+
+	handler := s.Secure(newOKHandler())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "example.com"
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, rr.Header().Get("X-Frame-Options"))
+	assert.Empty(t, rr.Header().Get("X-Content-Type-Options"))
+	assert.Empty(t, rr.Header().Get("Strict-Transport-Security"))
+	assert.Empty(t, rr.Header().Get("Content-Security-Policy"))
+}
+
+func TestSecure_CustomConfig_OverridesDefaults(t *testing.T) {
+	s := middleware.NewMiddleware()
+	s.SetSecure(true)
+	s.AddSecureConfig("example.com", middleware.SecureConfig{
+		XFrameOptions:       "SAMEORIGIN",
+		XContentTypeOptions: false,
+		CSP:                 "default-src 'self'; script-src 'self' 'unsafe-inline'",
+		ReferrerPolicy:      "no-referrer",
+	})
+
+	handler := s.Secure(newOKHandler())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "example.com"
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, "SAMEORIGIN", rr.Header().Get("X-Frame-Options"))
+	assert.Empty(t, rr.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t, "default-src 'self'; script-src 'self' 'unsafe-inline'", rr.Header().Get("Content-Security-Policy"))
+	assert.Equal(t, "no-referrer", rr.Header().Get("Referrer-Policy"))
+}
+
+func TestSecure_DomainSpecificConfigs(t *testing.T) {
+	s := middleware.NewMiddleware()
+	s.SetSecure(true)
+
+	s.AddSecureConfig("example.com", middleware.SecureConfig{
+		XFrameOptions: "SAMEORIGIN",
+		CSP:           "default-src 'self'",
+	})
+
+	s.AddSecureConfig("api.example.com", middleware.SecureConfig{
+		XFrameOptions: "DENY",
+		CSP:           "default-src 'self'; connect-src 'self' https://api.example.com",
+	})
+
+	handler := s.Secure(newOKHandler())
+
+	tests := []struct {
+		name        string
+		host        string
+		expectedXFO string
+		expectedCSP string
+	}{
+		{
+			name:        "example.com gets SAMEORIGIN",
+			host:        "example.com",
+			expectedXFO: "SAMEORIGIN",
+			expectedCSP: "default-src 'self'",
+		},
+		{
+			name:        "api.example.com gets DENY",
+			host:        "api.example.com",
+			expectedXFO: "DENY",
+			expectedCSP: "default-src 'self'; connect-src 'self' https://api.example.com",
+		},
+		{
+			name:        "unknown domain gets defaults",
+			host:        "other.com",
+			expectedXFO: "DENY",
+			expectedCSP: "default-src 'self'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Host = tt.host
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, tt.expectedXFO, rr.Header().Get("X-Frame-Options"))
+			assert.Equal(t, tt.expectedCSP, rr.Header().Get("Content-Security-Policy"))
+		})
+	}
+}
+
+func TestSecure_HSTS_AllOptions(t *testing.T) {
+	s := middleware.NewMiddleware()
+	s.SetSecure(true)
+	s.AddSecureConfig("example.com", middleware.SecureConfig{
+		HSTSEnabled:           true,
+		HSTSMaxAge:            180 * 24 * time.Hour,
+		HSTSIncludeSubdomains: true,
+		HSTSPreload:           true,
+	})
+
+	handler := s.Secure(newOKHandler())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "example.com"
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	hsts := rr.Header().Get("Strict-Transport-Security")
+	assert.Contains(t, hsts, "max-age=15552000")
+	assert.Contains(t, hsts, "includeSubDomains")
+	assert.Contains(t, hsts, "preload")
+}
+
+func TestSecure_HSTS_Disabled(t *testing.T) {
+	s := middleware.NewMiddleware()
+	s.SetSecure(true)
+	s.AddSecureConfig("example.com", middleware.SecureConfig{
+		HSTSEnabled: false,
+	})
+
+	handler := s.Secure(newOKHandler())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "example.com"
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Empty(t, rr.Header().Get("Strict-Transport-Security"))
+}
+
+func TestSecure_HSTS_NoSubdomains(t *testing.T) {
+	s := middleware.NewMiddleware()
+	s.SetSecure(true)
+	s.AddSecureConfig("example.com", middleware.SecureConfig{
+		HSTSEnabled:           true,
+		HSTSMaxAge:            365 * 24 * time.Hour,
+		HSTSIncludeSubdomains: false,
+	})
+
+	handler := s.Secure(newOKHandler())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "example.com"
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	hsts := rr.Header().Get("Strict-Transport-Security")
+	assert.Equal(t, "max-age=31536000", hsts)
+}
+
+func TestSecure_PermissionsPolicy(t *testing.T) {
+	s := middleware.NewMiddleware()
+	s.SetSecure(true)
+	s.AddSecureConfig("example.com", middleware.SecureConfig{
+		PermissionsPolicy: "geolocation=(self), microphone=()",
+	})
+
+	handler := s.Secure(newOKHandler())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "example.com"
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, "geolocation=(self), microphone=()", rr.Header().Get("Permissions-Policy"))
+}
+
+func TestSecure_XXSSProtection_Disabled(t *testing.T) {
+	s := middleware.NewMiddleware()
+	s.SetSecure(true)
+	s.AddSecureConfig("example.com", middleware.SecureConfig{
+		XXSSProtection: "",
+	})
+
+	handler := s.Secure(newOKHandler())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "example.com"
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Empty(t, rr.Header().Get("X-XSS-Protection"))
+}
+
+func TestSecure_XFrameOptions_AllowFrom(t *testing.T) {
+	s := middleware.NewMiddleware()
+	s.SetSecure(true)
+	s.AddSecureConfig("example.com", middleware.SecureConfig{
+		XFrameOptions: "ALLOW-FROM https://trusted.com",
+	})
+
+	handler := s.Secure(newOKHandler())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "example.com"
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, "ALLOW-FROM https://trusted.com", rr.Header().Get("X-Frame-Options"))
+}
+
+func TestSecure_NextHandlerIsCalled(t *testing.T) {
+	called := false
+	s := middleware.NewMiddleware()
+	s.SetSecure(true)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	handler := s.Secure(next)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "example.com"
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.True(t, called, "next handler should be called")
+	assert.Equal(t, http.StatusCreated, rr.Code)
+}
+
+func TestSecure_MultipleSetSecureCalls(t *testing.T) {
+	s := middleware.NewMiddleware()
+	s.SetSecure(false)
+	s.SetSecure(true)
+
+	handler := s.Secure(newOKHandler())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "example.com"
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.NotEmpty(t, rr.Header().Get("X-Frame-Options"))
+}
+
+func TestSecure_AppendSecureConfigs(t *testing.T) {
+	s := middleware.NewMiddleware()
+	s.SetSecure(true)
+
+	s.AddSecureConfig("one.com", middleware.SecureConfig{
+		XFrameOptions: "SAMEORIGIN",
+	})
+
+	s.AddSecureConfig("two.com", middleware.SecureConfig{
+		XFrameOptions: "DENY",
+	})
+
+	handler := s.Secure(newOKHandler())
+
+	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req1.Host = "one.com"
+	rr1 := httptest.NewRecorder()
+	handler.ServeHTTP(rr1, req1)
+	assert.Equal(t, "SAMEORIGIN", rr1.Header().Get("X-Frame-Options"))
+
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req2.Host = "two.com"
+	rr2 := httptest.NewRecorder()
+	handler.ServeHTTP(rr2, req2)
+	assert.Equal(t, "DENY", rr2.Header().Get("X-Frame-Options"))
+}
+
+func TestSetSecureConfig_UpdatesExisting(t *testing.T) {
+	s := middleware.NewMiddleware()
+	s.SetSecure(true)
+
+	s.SetSecureConfig("example.com", middleware.SecureConfig{
+		XFrameOptions: "SAMEORIGIN",
+	})
+
+	s.SetSecureConfig("example.com", middleware.SecureConfig{
+		XFrameOptions: "DENY",
+	})
+
+	handler := s.Secure(newOKHandler())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "example.com"
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, "DENY", rr.Header().Get("X-Frame-Options"))
+}
+
+func TestSecureConfig_WithHostPort(t *testing.T) {
+	s := middleware.NewMiddleware()
+	s.SetSecure(true)
+
+	s.AddSecureConfig("example.com:8080", middleware.SecureConfig{
+		XFrameOptions: "SAMEORIGIN",
+	})
+
+	handler := s.Secure(newOKHandler())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "example.com:8080"
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, "SAMEORIGIN", rr.Header().Get("X-Frame-Options"))
+}
+
+func TestSecure_EmptyHostFallsBackToDefault(t *testing.T) {
+	s := middleware.NewMiddleware()
+	s.SetSecure(true)
+
+	handler := s.Secure(newOKHandler())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = ""
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, "DENY", rr.Header().Get("X-Frame-Options"))
+	assert.Equal(t, "default-src 'self'", rr.Header().Get("Content-Security-Policy"))
+}
+
+func TestSecure_CSPWithReportURI(t *testing.T) {
+	s := middleware.NewMiddleware()
+	s.SetSecure(true)
+	s.AddSecureConfig("example.com", middleware.SecureConfig{
+		CSP: "default-src 'self'; report-uri /csp-report",
+	})
+
+	handler := s.Secure(newOKHandler())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "example.com"
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, "default-src 'self'; report-uri /csp-report", rr.Header().Get("Content-Security-Policy"))
+}
+
+func TestSecure_ReferrerPolicy_Values(t *testing.T) {
+	testCases := []struct {
+		policy   string
+		expected string
+	}{
+		{"no-referrer", "no-referrer"},
+		{"no-referrer-when-downgrade", "no-referrer-when-downgrade"},
+		{"origin", "origin"},
+		{"origin-when-cross-origin", "origin-when-cross-origin"},
+		{"same-origin", "same-origin"},
+		{"strict-origin", "strict-origin"},
+		{"strict-origin-when-cross-origin", "strict-origin-when-cross-origin"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.policy, func(t *testing.T) {
+			s := middleware.NewMiddleware()
+			s.SetSecure(true)
+			s.AddSecureConfig("example.com", middleware.SecureConfig{
+				ReferrerPolicy: tc.policy,
+			})
+
+			handler := s.Secure(newOKHandler())
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Host = "example.com"
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, tc.expected, rr.Header().Get("Referrer-Policy"))
+		})
+	}
+}
+
+func TestSecure_XContentTypeOptions_NosniffOnly(t *testing.T) {
+	s := middleware.NewMiddleware()
+	s.SetSecure(true)
+	s.AddSecureConfig("example.com", middleware.SecureConfig{
+		XContentTypeOptions: true,
+	})
+
+	handler := s.Secure(newOKHandler())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "example.com"
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, "nosniff", rr.Header().Get("X-Content-Type-Options"))
+}
+
+func TestDefaultSecureConfig_Values(t *testing.T) {
+	cfg := middleware.DefaultSecureConfig
+
+	assert.Equal(t, "DENY", cfg.XFrameOptions)
+	assert.True(t, cfg.XContentTypeOptions)
+	assert.Equal(t, "1; mode=block", cfg.XXSSProtection)
+	assert.True(t, cfg.HSTSEnabled)
+	assert.Equal(t, 365*24*time.Hour, cfg.HSTSMaxAge)
+	assert.True(t, cfg.HSTSIncludeSubdomains)
+	assert.False(t, cfg.HSTSPreload)
+	assert.Equal(t, "default-src 'self'", cfg.CSP)
+	assert.Equal(t, "strict-origin-when-cross-origin", cfg.ReferrerPolicy)
+	assert.Empty(t, cfg.PermissionsPolicy)
+}

--- a/middleware/secure_test.go
+++ b/middleware/secure_test.go
@@ -52,10 +52,10 @@ func TestSecure_CustomConfig_OverridesDefaults(t *testing.T) {
 	s := middleware.NewMiddleware()
 	s.SetSecure(true)
 	s.AddSecureConfig("example.com", middleware.SecureConfig{
-		XFrameOptions:       middleware.StrPtr("SAMEORIGIN"),
-		XContentTypeOptions: middleware.BoolPtr(false),
-		CSP:                 middleware.StrPtr("default-src 'self'; script-src 'self' 'unsafe-inline'"),
-		ReferrerPolicy:      middleware.StrPtr("no-referrer"),
+		XFrameOptions:       middleware.Ptr("SAMEORIGIN"),
+		XContentTypeOptions: middleware.Ptr(false),
+		CSP:                 middleware.Ptr("default-src 'self'; script-src 'self' 'unsafe-inline'"),
+		ReferrerPolicy:      middleware.Ptr("no-referrer"),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -76,13 +76,13 @@ func TestSecure_DomainSpecificConfigs(t *testing.T) {
 	s.SetSecure(true)
 
 	s.AddSecureConfig("example.com", middleware.SecureConfig{
-		XFrameOptions: middleware.StrPtr("SAMEORIGIN"),
-		CSP:           middleware.StrPtr("default-src 'self'"),
+		XFrameOptions: middleware.Ptr("SAMEORIGIN"),
+		CSP:           middleware.Ptr("default-src 'self'"),
 	})
 
 	s.AddSecureConfig("api.example.com", middleware.SecureConfig{
-		XFrameOptions: middleware.StrPtr("DENY"),
-		CSP:           middleware.StrPtr("default-src 'self'; connect-src 'self' https://api.example.com"),
+		XFrameOptions: middleware.Ptr("DENY"),
+		CSP:           middleware.Ptr("default-src 'self'; connect-src 'self' https://api.example.com"),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -131,10 +131,10 @@ func TestSecure_HSTS_AllOptions(t *testing.T) {
 	s := middleware.NewMiddleware()
 	s.SetSecure(true)
 	s.AddSecureConfig("example.com", middleware.SecureConfig{
-		HSTSEnabled:           middleware.BoolPtr(true),
-		HSTSMaxAge:            middleware.DurationPtr(180 * 24 * time.Hour),
-		HSTSIncludeSubdomains: middleware.BoolPtr(true),
-		HSTSPreload:           middleware.BoolPtr(true),
+		HSTSEnabled:           middleware.Ptr(true),
+		HSTSMaxAge:            middleware.Ptr(180 * 24 * time.Hour),
+		HSTSIncludeSubdomains: middleware.Ptr(true),
+		HSTSPreload:           middleware.Ptr(true),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -154,7 +154,7 @@ func TestSecure_HSTS_Disabled(t *testing.T) {
 	s := middleware.NewMiddleware()
 	s.SetSecure(true)
 	s.AddSecureConfig("example.com", middleware.SecureConfig{
-		HSTSEnabled: middleware.BoolPtr(false),
+		HSTSEnabled: middleware.Ptr(false),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -171,9 +171,9 @@ func TestSecure_HSTS_NoSubdomains(t *testing.T) {
 	s := middleware.NewMiddleware()
 	s.SetSecure(true)
 	s.AddSecureConfig("example.com", middleware.SecureConfig{
-		HSTSEnabled:           middleware.BoolPtr(true),
-		HSTSMaxAge:            middleware.DurationPtr(365 * 24 * time.Hour),
-		HSTSIncludeSubdomains: middleware.BoolPtr(false),
+		HSTSEnabled:           middleware.Ptr(true),
+		HSTSMaxAge:            middleware.Ptr(365 * 24 * time.Hour),
+		HSTSIncludeSubdomains: middleware.Ptr(false),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -191,7 +191,7 @@ func TestSecure_PermissionsPolicy(t *testing.T) {
 	s := middleware.NewMiddleware()
 	s.SetSecure(true)
 	s.AddSecureConfig("example.com", middleware.SecureConfig{
-		PermissionsPolicy: middleware.StrPtr("geolocation=(self), microphone=()"),
+		PermissionsPolicy: middleware.Ptr("geolocation=(self), microphone=()"),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -208,7 +208,7 @@ func TestSecure_XXSSProtection_Disabled(t *testing.T) {
 	s := middleware.NewMiddleware()
 	s.SetSecure(true)
 	s.AddSecureConfig("example.com", middleware.SecureConfig{
-		XXSSProtection: middleware.StrPtr(""),
+		XXSSProtection: middleware.Ptr(""),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -225,7 +225,7 @@ func TestSecure_XFrameOptions_AllowFrom(t *testing.T) {
 	s := middleware.NewMiddleware()
 	s.SetSecure(true)
 	s.AddSecureConfig("example.com", middleware.SecureConfig{
-		XFrameOptions: middleware.StrPtr("ALLOW-FROM https://trusted.com"),
+		XFrameOptions: middleware.Ptr("ALLOW-FROM https://trusted.com"),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -279,11 +279,11 @@ func TestSecure_AppendSecureConfigs(t *testing.T) {
 	s.SetSecure(true)
 
 	s.AddSecureConfig("one.com", middleware.SecureConfig{
-		XFrameOptions: middleware.StrPtr("SAMEORIGIN"),
+		XFrameOptions: middleware.Ptr("SAMEORIGIN"),
 	})
 
 	s.AddSecureConfig("two.com", middleware.SecureConfig{
-		XFrameOptions: middleware.StrPtr("DENY"),
+		XFrameOptions: middleware.Ptr("DENY"),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -306,11 +306,11 @@ func TestSetSecureConfig_UpdatesExisting(t *testing.T) {
 	s.SetSecure(true)
 
 	s.SetSecureConfig("example.com", middleware.SecureConfig{
-		XFrameOptions: middleware.StrPtr("SAMEORIGIN"),
+		XFrameOptions: middleware.Ptr("SAMEORIGIN"),
 	})
 
 	s.SetSecureConfig("example.com", middleware.SecureConfig{
-		XFrameOptions: middleware.StrPtr("DENY"),
+		XFrameOptions: middleware.Ptr("DENY"),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -328,7 +328,7 @@ func TestSecureConfig_WithHostPort(t *testing.T) {
 	s.SetSecure(true)
 
 	s.AddSecureConfig("example.com:8080", middleware.SecureConfig{
-		XFrameOptions: middleware.StrPtr("SAMEORIGIN"),
+		XFrameOptions: middleware.Ptr("SAMEORIGIN"),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -360,7 +360,7 @@ func TestSecure_CSPWithReportURI(t *testing.T) {
 	s := middleware.NewMiddleware()
 	s.SetSecure(true)
 	s.AddSecureConfig("example.com", middleware.SecureConfig{
-		CSP: middleware.StrPtr("default-src 'self'; report-uri /csp-report"),
+		CSP: middleware.Ptr("default-src 'self'; report-uri /csp-report"),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -392,7 +392,7 @@ func TestSecure_ReferrerPolicy_Values(t *testing.T) {
 			s := middleware.NewMiddleware()
 			s.SetSecure(true)
 			s.AddSecureConfig("example.com", middleware.SecureConfig{
-				ReferrerPolicy: middleware.StrPtr(tc.policy),
+				ReferrerPolicy: middleware.Ptr(tc.policy),
 			})
 
 			handler := s.Secure(newOKHandler())
@@ -411,7 +411,7 @@ func TestSecure_XContentTypeOptions_NosniffOnly(t *testing.T) {
 	s := middleware.NewMiddleware()
 	s.SetSecure(true)
 	s.AddSecureConfig("example.com", middleware.SecureConfig{
-		XContentTypeOptions: middleware.BoolPtr(true),
+		XContentTypeOptions: middleware.Ptr(true),
 	})
 
 	handler := s.Secure(newOKHandler())
@@ -444,7 +444,7 @@ func TestSecure_PartialConfig_MergesWithDefaults(t *testing.T) {
 	s.SetSecure(true)
 
 	s.AddSecureConfig("example.com", middleware.SecureConfig{
-		XFrameOptions: middleware.StrPtr("SAMEORIGIN"),
+		XFrameOptions: middleware.Ptr("SAMEORIGIN"),
 	})
 
 	handler := s.Secure(newOKHandler())


### PR DESCRIPTION
## Summary
- Add Secure middleware with support for:
  - X-Frame-Options
  - X-Content-Type-Options
  - X-XSS-Protection
  - Strict-Transport-Security (HSTS)
  - Content-Security-Policy
  - Referrer-Policy
  - Permissions-Policy

- Domain-specific configuration support (like CORS)
- Toggle via SetSecure(true/false)
- Default production-safe values

## Usage
```go
s := middleware.NewMiddleware()
s.SetSecure(true)

// Custom config for specific domain
s.AddSecureConfig("example.com", middleware.SecureConfig{
    XFrameOptions: "SAMEORIGIN",
    CSP: "default-src 'self'; script-src 'self'",
})
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bugfixes/go-bugfixes/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
